### PR TITLE
bugfix: not() returns false for empty nodeset

### DIFF
--- a/src/openrosa-extensions.js
+++ b/src/openrosa-extensions.js
@@ -284,7 +284,7 @@ const openrosa_xpath_extensions = function() {
     not: function(r) {
       if(arguments.length === 0) throw TOO_FEW_ARGS;
       if(arguments.length > 1) throw TOO_MANY_ARGS;
-      return XPR.boolean(!r.v);
+      return XPR.boolean(!asBoolean(r));
     },
     now: function() {
       return XPR.date(new Date());

--- a/test/integration/openrosa-xpath/not.spec.js
+++ b/test/integration/openrosa-xpath/not.spec.js
@@ -1,4 +1,5 @@
-const { assertThrow, assertTrue, assertFalse } = require('../helpers');
+const { assert } = require('chai');
+const { assertThrow, assertTrue, assertFalse, initDoc } = require('../helpers');
 
 describe('not', () => {
   it('not()', () => {
@@ -15,5 +16,25 @@ describe('not', () => {
 
   it('not() fails when too many arguments are provided', () => {
     assertThrow('not(1, 2)');
+  });
+
+  describe('referencing nodesets', () => {
+    const doc = initDoc(`
+      <countries>
+        <country>
+        </country>
+      </countries>
+    `);
+
+    [
+      [     'not(/cities)'    , true  ],
+      [ 'not(not(/cities))'   , false ],
+      [     'not(/countries)' , false ],
+      [ 'not(not(/countries))', true  ],
+    ].forEach(([ expr, expected ]) => {
+      it(`should evaluate '${expr}' as '${expected}'`, () => {
+        assert.equal(doc.xEval(expr).booleanValue, expected);
+      });
+    });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/enketo/openrosa-xpath-evaluator/issues/102