### PR TITLE
Convert date extensions to plain functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,41 @@
         }
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+      "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.0.2.tgz",
+      "integrity": "sha512-jxPRPp9n93ci7b8hMfJOFDPRLFYadN6FSpeROFTR4UNF4i5b+EK6m4QXPO46BDhFgRy1JuS87zAnFOzCUwMJcQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@types/component-emitter": {
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.10.tgz",
@@ -1544,6 +1579,12 @@
         "is-docker": "^2.0.0"
       }
     },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
     "isbinaryfile": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.6.tgz",
@@ -1626,6 +1667,12 @@
       "requires": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
     },
     "karma": {
       "version": "6.2.0",
@@ -1737,6 +1784,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "log-symbols": {
@@ -2064,6 +2117,19 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
+    "nise": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.0.tgz",
+      "integrity": "sha512-W5WlHu+wvo3PaKLsJJkgPup2LrsXCcm7AWwyNZkUnn5rwPkuPBi3Iwk5SQtN0mv+K65k7nKKjwNQ30wg3wLAQQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^7.0.4",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
     "node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
@@ -2182,6 +2248,15 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      }
     },
     "pathval": {
       "version": "1.1.1",
@@ -2429,6 +2504,37 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
+    },
+    "sinon": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.1.tgz",
+      "integrity": "sha512-ZSSmlkSyhUWbkF01Z9tEbxZLF/5tRC9eojCdFh33gtQaP7ITQVaMWQHGuFM7Cuf/KEfihuh1tTl3/ABju3AQMg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^7.1.0",
+        "@sinonjs/samsam": "^6.0.2",
+        "diff": "^5.0.0",
+        "nise": "^5.1.0",
+        "supports-color": "^7.2.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "slice-ansi": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -42,8 +42,5 @@
   },
   "peerDependencies": {
     "node-forge": "^0.10.0"
-  },
-  "volta": {
-    "node": "12.22.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,9 +37,13 @@
     "mocha": "^8.3.2",
     "node-forge": "^0.10.0",
     "puppeteer": "^8.0.0",
+    "sinon": "^11.1.1",
     "webpack": "^5.26.3"
   },
   "peerDependencies": {
     "node-forge": "^0.10.0"
+  },
+  "volta": {
+    "node": "12.22.1"
   }
 }

--- a/src/date-extensions.js
+++ b/src/date-extensions.js
@@ -1,5 +1,7 @@
 // imported from https://github.com/enketo/enketo-xpathjs/blob/master/src/date-extensions.js
-// TODO probably shouldn't be changing Date.prototype
+// TODO probably shouldn't be changing Date.prototype - when these can be safely removed,
+// these functions would probably more appropriately be in utils/date.js
+
 /**
  * Converts a native Date UTC String to a RFC 3339-compliant date string with local offsets
  * used in ODK, so it replaces the Z in the ISOstring with a local offset
@@ -14,7 +16,7 @@ const toISOLocalString = (date) => {
   }
 
   var dt = new Date(date.getTime() - (date.getTimezoneOffset() * 60 * 1000)).toISOString()
-      .replace('Z', date.getTimezoneOffsetAsTime());
+      .replace('Z', getTimezoneOffsetAsTime(date));
 
   if(dt.indexOf('T00:00:00.000') > 0) {
     return dt.split('T')[0];

--- a/src/date-extensions.js
+++ b/src/date-extensions.js
@@ -3,17 +3,18 @@
 /**
  * Converts a native Date UTC String to a RFC 3339-compliant date string with local offsets
  * used in ODK, so it replaces the Z in the ISOstring with a local offset
+ * @param {Date} date
  * @return {string} a datetime string formatted according to RC3339 with local offset
  */
-Date.prototype.toISOLocalString = function() {
+const toISOLocalString = (date) => {
   //2012-09-05T12:57:00.000-04:00 (ODK)
 
-  if(this.toString() === 'Invalid Date') {
-    return this.toString();
+  if(date.toString() === 'Invalid Date') {
+    return date.toString();
   }
 
-  var dt = new Date(this.getTime() - (this.getTimezoneOffset() * 60 * 1000)).toISOString()
-      .replace('Z', this.getTimezoneOffsetAsTime());
+  var dt = new Date(date.getTime() - (date.getTimezoneOffset() * 60 * 1000)).toISOString()
+      .replace('Z', date.getTimezoneOffsetAsTime());
 
   if(dt.indexOf('T00:00:00.000') > 0) {
     return dt.split('T')[0];
@@ -22,7 +23,11 @@ Date.prototype.toISOLocalString = function() {
   }
 };
 
-Date.prototype.getTimezoneOffsetAsTime = function() {
+/**
+ * @param {Date} date
+ * @return {string}
+ */
+const getTimezoneOffsetAsTime = (date) => {
   var offsetMinutesTotal;
   var hours;
   var minutes;
@@ -31,15 +36,36 @@ Date.prototype.getTimezoneOffsetAsTime = function() {
     return (x < 10) ? '0' + x : x;
   };
 
-  if(this.toString() === 'Invalid Date') {
-    return this.toString();
+  if(date.toString() === 'Invalid Date') {
+    return date.toString();
   }
 
-  offsetMinutesTotal = this.getTimezoneOffset();
+  offsetMinutesTotal = date.getTimezoneOffset();
 
   direction = (offsetMinutesTotal < 0) ? '+' : '-';
   hours = pad2(Math.floor(Math.abs(offsetMinutesTotal / 60)));
   minutes = pad2(Math.floor(Math.abs(offsetMinutesTotal % 60)));
 
   return direction + hours + ':' + minutes;
+};
+
+/**
+ * @deprecated
+ * @see {toISOLocalString}
+ */
+Date.prototype.toISOLocalString = function() {
+  return toISOLocalString(this);
+};
+
+/**
+ * @deprecated
+ * @see {getTimezoneOffsetAsTime}
+ */
+Date.prototype.getTimezoneOffsetAsTime = function() {
+  return getTimezoneOffsetAsTime(this);
+};
+
+module.exports = {
+  getTimezoneOffsetAsTime,
+  toISOLocalString,
 };

--- a/src/openrosa-extensions.js
+++ b/src/openrosa-extensions.js
@@ -1,4 +1,4 @@
-require('./date-extensions');
+const { getTimezoneOffsetAsTime } = require('./date-extensions');
 const { asGeopoints, area, distance } = require('./geo');
 const digest = require('./digest');
 const { randomToken } = require('./random-token');
@@ -563,7 +563,7 @@ function asDate(r) {
         temp = r.split('-');
         if(isValidDate(temp[0], temp[1], temp[2])) {
           const time = `${_zeroPad(temp[0])}-${_zeroPad(temp[1])}-${_zeroPad(temp[2])}`+
-            'T00:00:00.000' + (new Date(r)).getTimezoneOffsetAsTime();
+            'T00:00:00.000' + getTimezoneOffsetAsTime(new Date(r));
           return new Date(time);
         }
       }

--- a/src/utils/xpath-cast.js
+++ b/src/utils/xpath-cast.js
@@ -1,4 +1,5 @@
 const { DATE_STRING, dateToDays, dateStringToDays } = require('./date');
+const { toISOLocalString } = require('../date-extensions');
 
 module.exports = {
   asBoolean,
@@ -34,7 +35,7 @@ function asString(r) {
   switch(r.t) {
     case 'str':  return r.v;
     case 'arr':  return r.v.length ? r.v[0].textContent || '' : '';
-    case 'date': return r.v.toISOLocalString().replace(/T00:00:00.000.*/, ''); // TODO should be handled in an extension rather than core code
+    case 'date': return toISOLocalString(r.v).replace(/T00:00:00.000.*/, ''); // TODO should be handled in an extension rather than core code
     case 'num':
     case 'bool':
     default:     return r.v.toString();

--- a/test/unit/date-extensions.spec.js
+++ b/test/unit/date-extensions.spec.js
@@ -45,11 +45,16 @@ describe('Date helpers', () => {
     });
 
     describe('toISOLocalString', () => {
-      it('returns the ISO local string consistent with the time zone offset', () => {
-        const date = new Date('August 19, 1975 23:15:30 GMT+07:00');
+      it('returns the ISO local string consistent with a negative time zone offset', () => {
+        const date = new Date('1975-08-19T23:15:30.000+07:00');
+
         timezoneOffset = -60;
 
         assert.equal(date.toISOLocalString(), '1975-08-19T17:15:30.000+01:00');
+      });
+
+      it('returns the ISO local string consistent with a positive time zone offset', () => {
+        const date = new Date('1975-08-19T23:15:30.000+07:00');
 
         timezoneOffset = 60;
 
@@ -74,11 +79,16 @@ describe('Date helpers', () => {
     });
 
     describe('toISOLocalString', () => {
-      it('returns the ISO local string consistent with the time zone offset', () => {
-        const date = new Date('August 19, 1975 23:15:30 GMT+07:00');
+      it('returns the ISO local string consistent with a negative time zone offset', () => {
+        const date = new Date('1975-08-19T23:15:30.000+07:00');
+
         timezoneOffset = -60;
 
         assert.equal(toISOLocalString(date), '1975-08-19T17:15:30.000+01:00');
+      });
+
+      it('returns the ISO local string consistent with a positive time zone offset', () => {
+        const date = new Date('1975-08-19T23:15:30.000+07:00');
 
         timezoneOffset = 60;
 

--- a/test/unit/date-extensions.spec.js
+++ b/test/unit/date-extensions.spec.js
@@ -1,0 +1,89 @@
+/**
+ * @module date.spec
+ * @see {@link https://github.com/medic/cht-core/blob/2c1db1618bdafc5ec14c3a27aa4a37249fcc1b4a/webapp/tests/mocha/unit/enketo/medic-xpath-extensions.spec.js}
+ *
+ * Note: These tests were adapted from `medic/cht-core`.
+ */
+
+const { assert } = require('chai');
+const sinon = require('sinon');
+const { getTimezoneOffsetAsTime, toISOLocalString } = require('../../src/date-extensions');
+
+describe('Date helpers', () => {
+  /** @type {import('sinon').SinonSandbox} */
+  let sandbox;
+
+  /** @type {number} */
+  let timezoneOffset;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    timezoneOffset = 0;
+
+    sandbox.stub(Date.prototype, 'getTimezoneOffset')
+      .callsFake(() => timezoneOffset);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('legacy prototype methods', () => {
+    describe('getTimezoneOffsetAsTime', () => {
+      it('returns the time zone offset in hours when given a time zone difference in minutes', () => {
+        timezoneOffset = -60;
+
+        assert.equal((new Date()).getTimezoneOffsetAsTime(), '+01:00');
+      });
+
+      it('returns a negative time zone offset when given a positive time zone difference', () => {
+        timezoneOffset = 60;
+
+        assert.equal((new Date()).getTimezoneOffsetAsTime(), '-01:00');
+      });
+    });
+
+    describe('toISOLocalString', () => {
+      it('returns the ISO local string consistent with the time zone offset', () => {
+        const date = new Date('August 19, 1975 23:15:30 GMT+07:00');
+        timezoneOffset = -60;
+
+        assert.equal(date.toISOLocalString(), '1975-08-19T17:15:30.000+01:00');
+
+        timezoneOffset = 60;
+
+        assert.equal(date.toISOLocalString(), '1975-08-19T15:15:30.000-01:00');
+      });
+    });
+  });
+
+  describe('plain functions', () => {
+    describe('getTimezoneOffsetAsTime', () => {
+      it('returns the time zone offset in hours when given a time zone difference in minutes', () => {
+        timezoneOffset = -60;
+
+        assert.equal(getTimezoneOffsetAsTime(new Date()), '+01:00');
+      });
+
+      it('returns a negative time zone offset when given a positive time zone difference', () => {
+        timezoneOffset = 60;
+
+        assert.equal(getTimezoneOffsetAsTime(new Date()), '-01:00');
+      });
+    });
+
+    describe('toISOLocalString', () => {
+      it('returns the ISO local string consistent with the time zone offset', () => {
+        const date = new Date('August 19, 1975 23:15:30 GMT+07:00');
+        timezoneOffset = -60;
+
+        assert.equal(toISOLocalString(date), '1975-08-19T17:15:30.000+01:00');
+
+        timezoneOffset = 60;
+
+        assert.equal(toISOLocalString(date), '1975-08-19T15:15:30.000-01:00');
+      });
+    });
+  });
+});


### PR DESCRIPTION
This came up in enketo-core#791, where certain tests were depending on the Date.prototype monkeypatch side-effect before it had been performed. The intent in this change is to deprecate the prototype pollution by providing the same functionality as plain functions. Tests were adapted from medic/cht-core which appears to test a slightly different version of the same code.