### PR TITLE
Prepare for 2.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,19 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+[2.0.10] - 2022-02-01
+----------------------
+
+##### Fixed
+
+- Date arithmetic correctly returns a number, rather than a date (#143)
+- Date arithmetic correctly applies the local timezone to all operands (#147)
+- Values returned from `date` (and the `date-time` alias) always includes a time component, consistent with the previous evaluator (#148)
+
 [2.0.9] - 2021-10-11
 ---------------------
 ##### Fixed
-- `decimal-date-time()` treated as local time when no offset specified 
+- `decimal-date-time()` treated as local time when no offset specified
 
 [2.0.8] - 2021-09-10
 ---------------------

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openrosa-xpath-evaluator",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "openrosa-xpath-evaluator",
-      "version": "2.0.9",
+      "version": "2.0.10",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^4.3.4",
@@ -2925,6 +2925,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-8.0.0.tgz",
       "integrity": "sha512-D0RzSWlepeWkxPPdK3xhTcefj8rjah1791GE82Pdjsri49sy11ci/JQsAO8K2NRukqvwEtcI+ImP5F4ZiMvtIQ==",
+      "deprecated": "Version no longer supported. Upgrade to @latest",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openrosa-xpath-evaluator",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "Wrapper for browsers' XPath evaluator with added support for OpenRosa extensions.",
   "homepage": "https://enketo.org",
   "main": "src/openrosa-xpath.js",


### PR DESCRIPTION
- [x] Updated `CHANGELOG.md`
- [x] `npm test` passes
- [x] `npm audit` shows zero vulnerabilities