### PR TITLE
Update decimal-date-time function to support wider range of date strings

### DIFF
--- a/src/openrosa-extensions.js
+++ b/src/openrosa-extensions.js
@@ -154,7 +154,7 @@ const openrosa_xpath_extensions = function() {
     'decimal-date-time': function(r) {
       if(arguments.length > 1) throw TOO_MANY_ARGS;
 
-      const days = r.t === 'num' ? asNumber(r) : dateStringToDays(asString(r));
+      const days = r.t === 'num' ? asNumber(r) : dateToDays(asDate(r));
 
       return XPR.number(days);
     },

--- a/test/integration/openrosa-xpath/decimal-date-time.spec.js
+++ b/test/integration/openrosa-xpath/decimal-date-time.spec.js
@@ -43,8 +43,19 @@ describe('#decimal-date-time()', () => {
     assertThrow('decimal-date-time("1970-01-01T00:00:00.000Z", 2)');
   });
 
-  it('different format', () => {
-    // assertNumberRounded('decimal-date-time("2018-04-24T15:30:00.000+06:00")', 17645.396, 1000);
-    assertNumberValue('decimal-date-time("2018-04-24T15:30:00.000+06:00")', 17645.395833333332);
+  describe('different formats', () => {
+    it('should convert decimal-date-time("2018-04-24T15:30:00.000+06:00") into 17645.395833333332', () => {
+      assertNumberValue('decimal-date-time("2018-04-24T15:30:00.000+06:00")', 17645.395833333332);
+    });
+
+    [
+      ['decimal-date-time("1970/01/01")', 0.291667],
+      ['decimal-date-time("01/01/1970")', 0.291667],
+      ['decimal-date-time("Jan 01, 1970")', 0.291667],
+    ].forEach( ([expr, expectedDaysSinceEpoch]) => {
+      it('should convert ' + expr + ' into ' + expectedDaysSinceEpoch, () => {
+        assertNumberRounded(expr, expectedDaysSinceEpoch, 1000000);
+      });
+    });
   });
 });


### PR DESCRIPTION
Updates the `decimal-date-time` function to cast arguments to a date value (instead of a string) before calculating the number of days.  

This allows the function to leverage all the logic in [`asDate`](https://github.com/enketo/openrosa-xpath-evaluator/blob/fd05a1b29f59a6c070bcf7d6e738800e04832073/src/openrosa-extensions.js#L529) to convert the argument value.  

Closes #161 